### PR TITLE
Create an automated workflow to build official Docker images

### DIFF
--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -1,0 +1,53 @@
+name: dockerize
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker image tag'
+        default: 'dev'
+
+jobs:
+  build:
+    name: Publish Cohere Terrarium Docker Images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Get all history to correctly infer Khoj version using hatch
+          fetch-depth: 0
+
+      - name: 🧹 Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PAT }}
+
+      - name: 🧹 Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: 📦️⛅️ Build and Push Cloud Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ${{ github.ref_type == 'tag' && format('ghcr.io/{0}:latest', github.repository) || '' }}

--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          # Get all history to correctly infer Khoj version using hatch
           fetch-depth: 0
 
       - name: 🧹 Delete huge unnecessary tools folder


### PR DESCRIPTION
- Add a dockerize workflow that allows us to pull from an official Cohere build. Would output to `ghcr.io/cohere-ai/cohere-terrarium:latest`.
- Support the `workflow_dispatch` command for manually triggering builds

Addresses #4 