### PR TITLE
feat: requests package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/node_modules
+/dist
+/build
+/tests/file_io/_outputs/*
+/pyodide_cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "terrarium",
+  "name": "cohere-terrarium",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -10,7 +10,8 @@
         "clean": "^4.0.2",
         "express": "^4.19.2",
         "pyodide": "^0.24.1",
-        "typescript": "^5.4.3"
+        "typescript": "^5.4.3",
+        "xhr2": "^0.2.1"
       },
       "devDependencies": {
         "node-fetch": "^3.3.2",
@@ -1423,6 +1424,15 @@
         }
       }
     },
+    "node_modules/xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -2468,6 +2478,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "requires": {}
+    },
+    "xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "clean": "^4.0.2",
     "express": "^4.19.2",
     "pyodide": "^0.24.1",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.3",
+    "xhr2": "^0.2.1"
   },
   "scripts": {
     "build": "tsc",

--- a/tests/functionality/requests_http_get.py
+++ b/tests/functionality/requests_http_get.py
@@ -1,0 +1,8 @@
+from pyodide.http import pyfetch
+
+resp = await pyfetch("https://httpbin.org/get", method="GET")
+text = await resp.string()
+print("status:", resp.status)
+print("length:", len(text))
+assert resp.status == 200 and len(text) > 0
+

--- a/tests/functionality/urllib_http_get.py
+++ b/tests/functionality/urllib_http_get.py
@@ -1,0 +1,8 @@
+from pyodide.http import pyfetch
+
+resp = await pyfetch("https://httpbin.org/get", method="GET")
+data = await resp.bytes()
+print("status:", resp.status)
+print("length:", len(data))
+assert resp.status == 200 and len(data) > 0
+


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the project name and adds the `xhr2` dependency to enable HTTP networking in Python via Pyodide. It also includes the `pyodide-http` package to support HTTP requests in Python code.

- **Project Name Update**: The project name has been changed from `terrarium` to `cohere-terrarium` in `package.json` and `package-lock.json`.
- **Dependency Addition**: The `xhr2` dependency has been added to `package.json` and `package-lock.json` with version `^0.2.1`.
- **HTTP Networking Support**: The `xhr2` module is imported in `src/services/python-interpreter/service.ts` to enable HTTP networking in Python via Pyodide.
- **Pyodide-HTTP Integration**: The `pyodide-http` package is loaded and used to patch `urllib` and `requests` in Python code, enabling HTTP requests.
- **Test Cases**: New test cases have been added to `tests/functionality/requests_http_get.py` and `tests/functionality/urllib_http_get.py` to verify HTTP GET requests using `pyfetch` from `pyodide.http`.
- **Git Ignore Updates**: The `.gitignore` file has been updated to ignore additional directories and files, including `node_modules`, `dist`, `build`, `tests/file_io/_outputs/*`, and `pyodide_cache`.

<!-- end-generated-description -->