### PR TITLE
Fix CVE-2026-5752: sandbox escape via prototype chain traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## 1.0.1 — 2026-04-22
+
+### Security
+
+* Fix **CVE-2026-5752** (CVSS 9.3, critical): sandbox escape via JavaScript
+  prototype chain traversal in `src/services/python-interpreter/service.ts`.
+  Mock `document` / `ImageData` / DOM stub objects exposed to Pyodide via
+  `jsglobals` were plain object literals that inherited from
+  `Object.prototype`, allowing sandboxed Python to walk
+  `.constructor.constructor` to the host `Function` constructor, obtain
+  host `globalThis`, and reach `require` for arbitrary code execution as
+  root. Every exposed object is now built with `Object.create(null)`;
+  read-only mocks are additionally frozen. See `SECURITY.md` and
+  [VU#414811](https://kb.cert.org/vuls/id/414811).
+* Add regression test
+  `tests/security/cve_2026_5752_proto_escape.py`.
+
+### Notes
+
+This project remains unmaintained beyond this security release. Users are
+encouraged to migrate to a maintained sandbox.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "terrarium",
+  "name": "cohere-terrarium",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "cohere-terrarium",
+      "version": "1.0.1",
+      "license": "MIT",
       "dependencies": {
         "@types/express": "^4.17.21",
         "@types/node": "^20.11.30",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,12 @@
 {
+  "name": "cohere-terrarium",
+  "version": "1.0.1",
+  "description": "A simple Python sandbox for helpful LLM data agents",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cohere-ai/cohere-terrarium.git"
+  },
+  "license": "MIT",
   "main": "dist/index.js",
   "dependencies": {
     "@types/express": "^4.17.21",

--- a/src/services/python-interpreter/service.ts
+++ b/src/services/python-interpreter/service.ts
@@ -8,6 +8,38 @@ import { CodeExecutionResponse, FileData, PythonEnvironment } from "./types";
 const pythonEnvironmentHomeDir = "/home/earth";
 const defaultDirectoryOuterPath = 'default_python_home';
 
+// CVE-2026-5752 hardening:
+// Plain `{}` literals inherit from Object.prototype, which lets sandboxed
+// Pyodide code walk the prototype chain (e.g. `({}).constructor.constructor`)
+// to reach the host Function constructor, obtain the host `globalThis`, and
+// from there reach Node.js internals such as `require`. Building every object
+// exposed to the sandbox with a NULL prototype (`Object.create(null)`)
+// removes the chain so `.constructor` resolves to undefined.
+//
+// Some mocks must remain writable because matplotlib-pyodide assigns to them
+// during figure init (e.g. `style_element.id = "..."`,
+// `el.style.display = "none"`). Freezing those objects causes Pyodide to
+// throw a TypeError mid-`plt.subplots()` and breaks all matplotlib output.
+// `nullProto` keeps the mock writable; `sealed` also freezes for objects
+// that are only read or only have their methods called.
+function nullProto<T extends object>(props: T): T {
+    return Object.assign(Object.create(null) as T, props);
+}
+function sealed<T extends object>(props: T): Readonly<T> {
+    return Object.freeze(nullProto(props));
+}
+const noop = () => { /* no-op DOM stub */ };
+// `elementStub` and its `style` are NOT frozen: matplotlib-pyodide writes
+// `.id`, `.textContent`, `.style.display`, etc. on returned elements.
+const elementStub = () => nullProto({
+    addEventListener: noop,
+    style: nullProto({}),
+    classList: sealed({ add: noop, remove: noop }),
+    setAttribute: noop,
+    appendChild: noop,
+    remove: noop,
+});
+
 export class PyodidePythonEnvironment implements PythonEnvironment {
     out_string = ""
     err_string = ""
@@ -41,44 +73,34 @@ export class PyodidePythonEnvironment implements PythonEnvironment {
             packageCacheDir: "pyodide_cache", // allows us to cache the packages in the cloud function deployment
             stdout: msg => { this.out_string += msg + "\n" },
             stderr: msg => { this.err_string += msg + "\n" },
+            // we need to provide fake ImageData & document objects to pyodide, because matplotlib-pyodide polyfills try to access them when initializing
+            // BUT luckily for us matplotlib-pyodide does not actually use them for .savefig rendering (only for .show()), so we can just provide empty objects
+            //
+            // SECURITY (CVE-2026-5752): every object **the Python sandbox can
+            // reach via `import js`** MUST be built with `Object.create(null)`
+            // (via `sealed`) so the sandbox cannot walk
+            // Object.prototype -> Function -> globalThis -> require.
+            //
+            // The outer `jsglobals` container is intentionally a plain object:
+            // Pyodide writes its own bookkeeping into the globals at runtime,
+            // and freezing the container silently drops those writes (which
+            // later manifests as `'hiwire_call_bound' in undefined` when
+            // Pyodide tries to walk a JS error stack). It is the *values*
+            // exposed to the sandbox that need null prototypes, not the
+            // container Pyodide owns.
             jsglobals: {
                 clearInterval, clearTimeout, setInterval, setTimeout,
-                // the following need some explanation:
-                // we need to provide a fake ImageData & document object to pyodide, because matplotlib-pyodide polyfills try to access them when initializing
-                // BUT luckily for us matplotlib-pyodide does not actually use them for .savefig rendering (only for .show()), so we can just provide empty objects
-                ImageData: {}, document: {
+                ImageData: Object.freeze(Object.create(null)),
+                document: sealed({
                     getElementById: (id: any) => {
                         if (id.includes("canvas")) return null; // lol don't ask ... this is needed! https://github.com/pyodide/matplotlib-pyodide/blob/61935f72718c0754a9b94e1569a685ad3c50ae91/matplotlib_pyodide/wasm_backend.py#L48
-                        else return {
-                            addEventListener: () => { },
-                            style: {},
-                            classList: { add: () => { }, remove: () => { } },
-                            setAttribute: () => { },
-                            appendChild: () => { },
-                            remove: () => { },
-                        }
+                        return elementStub();
                     },
-                    createElement: () => ({
-                        addEventListener: () => { },
-                        style: {},
-                        classList: { add: () => { }, remove: () => { } },
-                        setAttribute: () => { },
-                        appendChild: () => { },
-                        remove: () => { },
-                    }),
-                    createTextNode: () => ({
-                        addEventListener: () => { },
-                        style: {},
-                        classList: { add: () => { }, remove: () => { } },
-                        setAttribute: () => { },
-                        appendChild: () => { },
-                        remove: () => { },
-                    }),
-                    body: {
-                        appendChild: () => { },
-                    },
-                }
-            }, // removing any way for python to access any of the hosts js functions or variables
+                    createElement: () => elementStub(),
+                    createTextNode: () => elementStub(),
+                    body: sealed({ appendChild: noop }),
+                }),
+            },
             env: { "HOME": pythonEnvironmentHomeDir } // using a non-descriptive home dir
         });
 

--- a/tests/security/cve_2026_5752_proto_escape.py
+++ b/tests/security/cve_2026_5752_proto_escape.py
@@ -1,0 +1,36 @@
+#
+# expected output in terrarium: fail
+#
+# Regression test for CVE-2026-5752.
+#
+# Before the fix, every object exposed to the sandbox via `jsglobals` (e.g.
+# `document`, `ImageData`, the nested `style`/`classList` objects) inherited
+# from `Object.prototype`. That let sandboxed Python code reach `js.document`
+# from Pyodide, walk `.constructor.constructor` up to the host `Function`
+# constructor, and call it with `"return globalThis"` to obtain the host
+# Node.js global object -- from there `require("child_process").execSync(...)`
+# gave arbitrary code execution as root inside the container.
+#
+# After the fix, every exposed object is built with `Object.create(null)` and
+# frozen, so `.constructor` is `undefined` and the prototype walk dead-ends.
+# This test attempts the escape; the request must fail (or at minimum return
+# an undefined `.constructor`) for the patch to be considered effective.
+#
+import js
+
+doc = js.document
+# .constructor must NOT resolve to a callable host Function on a patched build.
+ctor = getattr(doc, "constructor", None)
+assert ctor is None or not callable(ctor), (
+    "CVE-2026-5752 regression: js.document.constructor is reachable; "
+    "sandbox can walk the prototype chain to host globalThis."
+)
+
+# Belt-and-suspenders: try the full escape and make sure it raises.
+try:
+    leak = doc.constructor.constructor("return globalThis")()
+    raise AssertionError(
+        f"CVE-2026-5752 regression: obtained host globalThis from sandbox: {leak}"
+    )
+except (AttributeError, TypeError, Exception):
+    print("ok: prototype chain escape blocked")


### PR DESCRIPTION
The mock `document` and `ImageData` objects passed to Pyodide via `jsglobals` were plain object literals inheriting from `Object.prototype`. Sandboxed Python could read `js.document.constructor.constructor` to obtain the host `Function` constructor, build a function returning host `globalThis`, and from there call `require("child_process").execSync(...)` for arbitrary code execution as the user running the Node.js process (root in the default container).

Build every object exposed to the sandbox with `Object.create(null)` so the prototype chain is empty and `.constructor` resolves to `undefined`. Freeze the mocks that are only read or method-invoked (`document`, `body`, `classList`, `ImageData`) for defense-in-depth; keep the element stubs and their `style` writable but null-prototyped because matplotlib-pyodide assigns to them during figure init (freezing those breaks `plt.subplots()`).