### PR TITLE
Fix CODEOWNERS syntax for security approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 * @cohere-ai/rag
 
 ## Security can approve changes to CODEOWNERS:
-CODEOWNERS @cohere-ai/security
+* @cohere-ai/security


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the CODEOWNERS file.

- Removes the line "CODEOWNERS @cohere-ai/security"
- Adds the line "* @cohere-ai/security"

<!-- end-generated-description -->